### PR TITLE
allow network-3.2

### DIFF
--- a/mason.cabal
+++ b/mason.cabal
@@ -32,7 +32,7 @@ library
   build-depends:       base >= 4.12.0.0 && <5
     , bytestring
     , text
-    , network >= 2.7 && <3.2
+    , network >= 2.7 && <3.3
     , ghc-prim
     , array
   hs-source-dirs: src


### PR DESCRIPTION
fix #13. Tested using `cabal build -w ghc-9.6.6 -c 'network>=3.2'`
